### PR TITLE
Create a new constructor for StoreScanner to avoid flaky tests

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -84,7 +84,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
   private boolean parallelSeekEnabled = false;
   private ExecutorService executor;
   private final Scan scan;
-  private final long oldestUnexpiredTS;
+  private long oldestUnexpiredTS = 0L;
   private final long now;
   private final int minVersions;
   private final long maxRowSize;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -357,6 +357,18 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     seekAllScanner(scanInfo, scanners);
   }
 
+  // Almost the same as above except for settting the start time of oldestUnexpiredTS
+  StoreScanner(Scan scan, ScanInfo scanInfo, NavigableSet<byte[]> columns,
+    List<? extends KeyValueScanner> scanners, Long timeStampOrigin) throws IOException {
+    // 0 is passed as readpoint because the test bypasses Store
+    this(null, scan, scanInfo, columns != null ? columns.size() : 0, 0L,
+      scan.getCacheBlocks(), ScanType.USER_SCAN);
+    oldestUnexpiredTS = timeStampOrigin - scanInfo.getTtl();
+    this.matcher =
+      UserScanQueryMatcher.create(scan, scanInfo, columns, oldestUnexpiredTS, now, null);
+    seekAllScanner(scanInfo, scanners);
+  }
+
   // Used to instantiate a scanner for user scan in test
   StoreScanner(Scan scan, ScanInfo scanInfo, NavigableSet<byte[]> columns,
     List<? extends KeyValueScanner> scanners) throws IOException {
@@ -1241,7 +1253,4 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     }
   }
 
-  public long getOldestUnexpiredTS() {
-    return this.oldestUnexpiredTS;
-  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -1240,4 +1240,8 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
       trySwitchToStreamRead();
     }
   }
+
+  public long getOldestUnexpiredTS() {
+    return this.oldestUnexpiredTS;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -219,6 +219,11 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
       }
     }
   }
+  
+  private StoreScanner(HStore store, Scan scan, ScanInfo scanInfo, int numColumns, long readPt,
+    boolean cacheBlocks, ScanType scanType) {
+    this(store, scan, scanInfo, numColumns, readPt, cacheBlocks, scanType, null);
+  }
 
   private void addCurrentScanners(List<? extends KeyValueScanner> scanners) {
     this.currentScanners.addAll(scanners);
@@ -234,7 +239,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
   public StoreScanner(HStore store, ScanInfo scanInfo, Scan scan, NavigableSet<byte[]> columns,
     long readPt) throws IOException {
     this(store, scan, scanInfo, columns != null ? columns.size() : 0, readPt, scan.getCacheBlocks(),
-      ScanType.USER_SCAN, null);
+      ScanType.USER_SCAN);
     if (columns != null && scan.isRaw()) {
       throw new DoNotRetryIOException("Cannot specify any column for a raw scan");
     }
@@ -311,7 +316,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     ScanType scanType, long smallestReadPoint, long earliestPutTs, byte[] dropDeletesFromRow,
     byte[] dropDeletesToRow) throws IOException {
     this(store, SCAN_FOR_COMPACTION, scanInfo, 0,
-      store.getHRegion().getReadPoint(IsolationLevel.READ_COMMITTED), false, scanType, null);
+      store.getHRegion().getReadPoint(IsolationLevel.READ_COMMITTED), false, scanType);
     assert scanType != ScanType.USER_SCAN;
     matcher =
       CompactionScanQueryMatcher.create(scanInfo, scanType, smallestReadPoint, earliestPutTs,
@@ -338,7 +343,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
   // For mob compaction only as we do not have a Store instance when doing mob compaction.
   public StoreScanner(ScanInfo scanInfo, ScanType scanType,
     List<? extends KeyValueScanner> scanners) throws IOException {
-    this(null, SCAN_FOR_COMPACTION, scanInfo, 0, Long.MAX_VALUE, false, scanType, null);
+    this(null, SCAN_FOR_COMPACTION, scanInfo, 0, Long.MAX_VALUE, false, scanType);
     assert scanType != ScanType.USER_SCAN;
     this.matcher = CompactionScanQueryMatcher.create(scanInfo, scanType, Long.MAX_VALUE, 0L,
       oldestUnexpiredTS, now, null, null, null);
@@ -350,7 +355,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     List<? extends KeyValueScanner> scanners, ScanType scanType) throws IOException {
     // 0 is passed as readpoint because the test bypasses Store
     this(null, scan, scanInfo, columns != null ? columns.size() : 0, 0L, scan.getCacheBlocks(),
-      scanType, null);
+      scanType);
     if (scanType == ScanType.USER_SCAN) {
       this.matcher =
         UserScanQueryMatcher.create(scan, scanInfo, columns, oldestUnexpiredTS, now, null);
@@ -388,7 +393,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     List<? extends KeyValueScanner> scanners) throws IOException {
     // 0 is passed as readpoint because the test bypasses Store
     this(null, maxVersions > 0 ? new Scan().readVersions(maxVersions) : SCAN_FOR_COMPACTION,
-      scanInfo, 0, 0L, false, scanType, null);
+      scanInfo, 0, 0L, false, scanType);
     this.matcher = CompactionScanQueryMatcher.create(scanInfo, scanType, Long.MAX_VALUE,
       PrivateConstants.OLDEST_TIMESTAMP, oldestUnexpiredTS, now, null, null, null);
     seekAllScanner(scanInfo, scanners);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -366,7 +366,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     seekAllScanner(scanInfo, scanners);
   }
 
-  // Almost the same as above except for settting the start time of oldestUnexpiredTS
+  // Almost the same as below except for settting the start time of oldestUnexpiredTS
   StoreScanner(Scan scan, ScanInfo scanInfo, NavigableSet<byte[]> columns,
     List<? extends KeyValueScanner> scanners, Long timeStampOrigin) throws IOException {
     // 0 is passed as readpoint because the test bypasses Store

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -1252,5 +1252,4 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
       trySwitchToStreamRead();
     }
   }
-
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -382,7 +382,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     List<? extends KeyValueScanner> scanners) throws IOException {
     // 0 is passed as readpoint because the test bypasses Store
     this(null, scan, scanInfo, columns != null ? columns.size() : 0, 0L, scan.getCacheBlocks(),
-      ScanType.USER_SCAN, null);
+      ScanType.USER_SCAN);
     this.matcher =
       UserScanQueryMatcher.create(scan, scanInfo, columns, oldestUnexpiredTS, now, null);
     seekAllScanner(scanInfo, scanners);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
@@ -874,7 +874,7 @@ public class TestStoreScanner {
     scan.readVersions(1);
     ScanInfo scanInfo = new ScanInfo(CONF, CF, 0, 1, 500, KeepDeletedCells.FALSE,
       HConstants.DEFAULT_BLOCKSIZE, 0, CellComparator.getInstance(), false);
-    try (StoreScanner scanner = new StoreScanner(scan, scanInfo, null, scanners)) {
+    try (StoreScanner scanner = new StoreScanner(scan, scanInfo, null, scanners, now)) {
       List<Cell> results = new ArrayList<>();
       assertEquals(true, scanner.next(results));
       assertEquals(2, results.size());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
@@ -876,6 +876,9 @@ public class TestStoreScanner {
       HConstants.DEFAULT_BLOCKSIZE, 0, CellComparator.getInstance(), false);
     try (StoreScanner scanner = new StoreScanner(scan, scanInfo, null, scanners)) {
       List<Cell> results = new ArrayList<>();
+      if (scanner.getOldestUnexpiredTS() - now >= -200L) {
+        return;
+      }
       assertEquals(true, scanner.next(results));
       assertEquals(2, results.size());
       assertEquals(kvs[1], results.get(0));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
@@ -876,9 +876,6 @@ public class TestStoreScanner {
       HConstants.DEFAULT_BLOCKSIZE, 0, CellComparator.getInstance(), false);
     try (StoreScanner scanner = new StoreScanner(scan, scanInfo, null, scanners)) {
       List<Cell> results = new ArrayList<>();
-      if (scanner.getOldestUnexpiredTS() - now >= -200L) {
-        return;
-      }
       assertEquals(true, scanner.next(results));
       assertEquals(2, results.size());
       assertEquals(kvs[1], results.get(0));


### PR DESCRIPTION
## What is the purpose of this PR

- This PR fixes a flaky test caused by the  non-determinism of the amount of time that the unit test ```testWildCardTtlScan()``` takes to run.
- In other words, the test may randomly fail or pass when run on a slow enough machine.

## Reproduce the test failure

- Run test ```testWildCardTtlScan()``` for many times in a slow enough machine.
- To reproduce the failure more often, we can add ```Thread.sleep(1000);``` after getting the current time (line 862) and before creating the object of ```StoreScanner```(line 877) in the  ```TestStoreScanner.java``` file to simulate a slow machine.

## Expected result:

- The test should run successfully regardless of the amount of time  between getting current time (line 862) and creating the object of StoreScanner (line 877), regardless of the speed of running tests.

## Actual result:

- We can get the stack trace of test failure as below

```
 java.lang.AssertionError: expected:<2> but was:<0>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.apache.hadoop.hbase.regionserver.TestStoreScanner.testWildCardTtlScan(TestStoreScanner.java:856)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

## Why the test fails

- The time to create the keyValue array is different from that of creating the ```StoreScanner``` object.

  i.e., for line 175 in file ```StoreScanner.java```:

  ```this.oldestUnexpiredTS = scan.isRaw() ? 0L : now - scanInfo.getTtl();```

  the variable "now" is different from the variable "now" that line 836 gets  in the ```TestStoreScanner.java```  file:

  ```long now = System.currentTimeMillis();```

## Fix

Create a new constructor for ```StoreScanner``` and modify the internal constructor to receive a new parameter, which enables us to set the start time of finding kvs.